### PR TITLE
fixed no error return when occured already exist genesis file.

### DIFF
--- a/contrib/launchtools/steps/genesis.go
+++ b/contrib/launchtools/steps/genesis.go
@@ -114,7 +114,7 @@ func initializeGenesis(
 	// prepare genesis
 	genFilePath := cometConfig.GenesisFile()
 	if cometos.FileExists(genFilePath) {
-		return nil, errors.Wrap(err, "genesis file already exists")
+		return nil, errors.New("genesis file already exists")
 	}
 
 	// prepare default genesis


### PR DESCRIPTION
InitalizeGenesis function is not returning both error and appGenesis when already exist genesis file.
So error checking statement is ignored and an NPE error occurs.