### PR TITLE
audit

### DIFF
--- a/x/ophost/keeper/msg_server.go
+++ b/x/ophost/keeper/msg_server.go
@@ -508,7 +508,7 @@ func (ms MsgServer) UpdateOracleConfig(ctx context.Context, req *types.MsgUpdate
 	}
 
 	sdk.UnwrapSDKContext(ctx).EventManager().EmitEvent(sdk.NewEvent(
-		types.EventTypeUpdateBatchInfo,
+		types.EventTypeUpdateOracle,
 		sdk.NewAttribute(types.AttributeKeyBridgeId, strconv.FormatUint(bridgeId, 10)),
 		sdk.NewAttribute(types.AttributeKeyOracleEnabled, strconv.FormatBool(config.OracleEnabled)),
 	))

--- a/x/ophost/types/event.go
+++ b/x/ophost/types/event.go
@@ -11,6 +11,7 @@ const (
 	EventTypeUpdateChallenger        = "update_challenger"
 	EventTypeUpdateBatchInfo         = "update_batch_info"
 	EventTypeUpdateMetadata          = "update_metadata"
+	EventTypeUpdateOracle            = "update_oracle"
 
 	AttributeKeySubmitter              = "submitter"
 	AttributeKeyCreator                = "creator"


### PR DESCRIPTION
1. Emit EventTypeUpdateOracle instead of EventTypeUpdateBatchInfo when updating oracle config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event type, `EventTypeUpdateOracle`, enhancing event tracking for oracle updates.
	- Added new message handling methods for improved bridge operations.

- **Improvements**
	- Enhanced permission checks for various methods to ensure secure updates.
	- Improved error handling for token deposit and withdrawal processes.

These changes collectively enhance the security and functionality of bridge operations within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->