### PR TITLE
allow authz msgupdateoracle to systemlane

### DIFF
--- a/x/opchild/lanes/free.go
+++ b/x/opchild/lanes/free.go
@@ -39,8 +39,16 @@ func (h FreeLaneMatchHandler) MatchHandler() base.MatchHandler {
 		} else if payer, err := h.ac.BytesToString(feeTx.FeePayer()); err != nil {
 			return false
 		} else {
+			var granter string
+			if feeTx.FeeGranter() != nil {
+				granter, err = h.ac.BytesToString(feeTx.FeeGranter())
+				if err != nil {
+					return false
+				}
+			}
+
 			for _, addr := range whitelist {
-				if addr == payer {
+				if addr == payer || addr == granter {
 					return true
 				}
 			}

--- a/x/opchild/lanes/free_test.go
+++ b/x/opchild/lanes/free_test.go
@@ -52,14 +52,30 @@ func Test_FreeLaneMatchHandler(t *testing.T) {
 	require.True(t, handler(ctx, MockTx{
 		feePayer: []byte{3, 4, 5, 6},
 	}))
+
+	require.True(t, handler(ctx, MockTx{
+		feePayer:   []byte{2, 3, 4, 5},
+		feeGranter: []byte{0, 1, 2, 3},
+	}))
+
+	require.True(t, handler(ctx, MockTx{
+		feePayer:   []byte{2, 3, 4, 5},
+		feeGranter: []byte{3, 4, 5, 6},
+	}))
+
+	require.False(t, handler(ctx, MockTx{
+		feePayer:   []byte{2, 3, 4, 5},
+		feeGranter: []byte{2, 3, 5, 6},
+	}))
 }
 
 var _ sdk.Tx = MockTx{}
 var _ sdk.FeeTx = &MockTx{}
 
 type MockTx struct {
-	msgs     []sdk.Msg
-	feePayer []byte
+	msgs       []sdk.Msg
+	feePayer   []byte
+	feeGranter []byte
 }
 
 func (tx MockTx) GetMsgsV2() ([]protov2.Message, error) {
@@ -82,5 +98,5 @@ func (tx MockTx) FeePayer() []byte {
 	return tx.feePayer
 }
 func (tx MockTx) FeeGranter() []byte {
-	return nil
+	return tx.feeGranter
 }

--- a/x/opchild/lanes/system.go
+++ b/x/opchild/lanes/system.go
@@ -5,6 +5,7 @@ import (
 
 	blockbase "github.com/skip-mev/block-sdk/v2/block/base"
 
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/initia-labs/OPinit/x/opchild/types"
 )
 
@@ -16,8 +17,15 @@ func SystemLaneMatchHandler() blockbase.MatchHandler {
 		}
 
 		for _, msg := range tx.GetMsgs() {
-			switch msg.(type) {
+			switch msg := msg.(type) {
 			case *types.MsgUpdateOracle:
+			case *authz.MsgExec:
+				msgs, err := msg.GetMessages()
+				if err != nil || len(msgs) != 1 {
+					return false
+				} else if _, ok := msgs[0].(*types.MsgUpdateOracle); !ok {
+					return false
+				}
 			default:
 				return false
 			}

--- a/x/opchild/lanes/system_test.go
+++ b/x/opchild/lanes/system_test.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/cometbft/cometbft/proto/tendermint/types"
@@ -39,6 +40,28 @@ func Test_SystemLaneMatchHandler(t *testing.T) {
 	require.False(t, handler(ctx, MockTx{
 		msgs: []sdk.Msg{
 			&banktypes.MsgSend{},
+		},
+	}))
+
+	authzMsg := authz.NewMsgExec(nil, []sdk.Msg{
+		&opchildtypes.MsgUpdateOracle{},
+	})
+
+	// 1 system message and authz.MsgExec
+	require.True(t, handler(ctx, MockTx{
+		msgs: []sdk.Msg{
+			&authzMsg,
+		},
+	}))
+
+	authzMsg = authz.NewMsgExec(nil, []sdk.Msg{
+		&banktypes.MsgSend{},
+	})
+
+	// authz.MsgExec with non-system message
+	require.False(t, handler(ctx, MockTx{
+		msgs: []sdk.Msg{
+			&authzMsg,
 		},
 	}))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced match handling to support fee granter addresses, allowing for broader criteria in successful matches.
	- Updated system lane match handling to process authorization messages.

- **Bug Fixes**
	- Improved logic to ensure proper handling of various message types within the match handler.

- **Tests**
	- Expanded test coverage for match handlers, including scenarios with fee granters and authorization messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->