### PR TITLE
remove initiate withdrawal when deposit hook failed

### DIFF
--- a/x/opchild/keeper/msg_server.go
+++ b/x/opchild/keeper/msg_server.go
@@ -459,17 +459,15 @@ func (ms MsgServer) FinalizeTokenDeposit(ctx context.Context, req *types.MsgFina
 	sdkCtx.EventManager().EmitEvent(depositEvent)
 
 	// if the deposit is failed, initiate a withdrawal to refund the deposit
-	if !depositSuccess {
-		if coin.IsPositive() {
-			l2Sequence, err := ms.IncreaseNextL2Sequence(ctx)
-			if err != nil {
-				return nil, err
-			}
+	if !depositSuccess && coin.IsPositive() {
+		l2Sequence, err := ms.IncreaseNextL2Sequence(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-			err = ms.emitWithdrawEvents(ctx, types.NewMsgInitiateTokenWithdrawal(req.To, req.From, coin), l2Sequence)
-			if err != nil {
-				return nil, err
-			}
+		err = ms.emitWithdrawEvents(ctx, types.NewMsgInitiateTokenWithdrawal(req.To, req.From, coin), l2Sequence)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/x/opchild/keeper/msg_server.go
+++ b/x/opchild/keeper/msg_server.go
@@ -524,7 +524,7 @@ func (ms MsgServer) emitWithdrawEvents(ctx context.Context, req *types.MsgInitia
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
- 	sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
+	sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeInitiateTokenWithdrawal,
 		sdk.NewAttribute(types.AttributeKeyFrom, req.Sender),
 		sdk.NewAttribute(types.AttributeKeyTo, req.To),

--- a/x/opchild/keeper/msg_server_test.go
+++ b/x/opchild/keeper/msg_server_test.go
@@ -428,19 +428,6 @@ func Test_MsgServer_Deposit_ToModuleAccount(t *testing.T) {
 
 	afterModuleBalance := input.BankKeeper.GetBalance(ctx, opchildModuleAddress, denom)
 	require.True(t, afterModuleBalance.Amount.IsZero())
-
-	// token withdrawal initiated
-	events := sdk.UnwrapSDKContext(ctx).EventManager().Events()
-	lastEvent := events[len(events)-1]
-	require.Equal(t, sdk.NewEvent(
-		types.EventTypeInitiateTokenWithdrawal,
-		sdk.NewAttribute(types.AttributeKeyFrom, opchildModuleAddress.String()),
-		sdk.NewAttribute(types.AttributeKeyTo, addrsStr[1]),
-		sdk.NewAttribute(types.AttributeKeyDenom, denom),
-		sdk.NewAttribute(types.AttributeKeyBaseDenom, "test_token"),
-		sdk.NewAttribute(types.AttributeKeyAmount, "100"),
-		sdk.NewAttribute(types.AttributeKeyL2Sequence, "1"),
-	), lastEvent)
 }
 
 func Test_MsgServer_Deposit_NoHook(t *testing.T) {
@@ -557,7 +544,7 @@ func Test_MsgServer_Deposit_HookFail(t *testing.T) {
 
 	// check receiver has no balance
 	afterBalance = input.BankKeeper.GetBalance(ctx, addr, denom)
-	require.Equal(t, math.NewInt(0), afterBalance.Amount)
+	require.Equal(t, math.NewInt(100), afterBalance.Amount)
 }
 
 func Test_MsgServer_Deposit_HookFail_WithOutOfGas(t *testing.T) {
@@ -614,7 +601,7 @@ func Test_MsgServer_Deposit_HookFail_WithOutOfGas(t *testing.T) {
 
 	// check receiver has no balance
 	afterBalance = input.BankKeeper.GetBalance(ctx, addr, denom)
-	require.Equal(t, math.NewInt(0), afterBalance.Amount)
+	require.Equal(t, math.NewInt(100), afterBalance.Amount)
 }
 
 func Test_MsgServer_UpdateOracle(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the token deposit process to ensure that balances remain unaffected when an invalid address is provided, while also emitting clear event notifications.
  - Adjusted balance assertions in tests to align with the updated logic for managing balances during deposit failures.

- **New Features**
  - Added a test for handling invalid address deposits, verifying that the appropriate events are emitted and balance states are correctly maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->