### PR TITLE
fix: introduce oracle update height buffer

### DIFF
--- a/x/opchild/keeper/oracle.go
+++ b/x/opchild/keeper/oracle.go
@@ -66,7 +66,7 @@ func (k L2OracleHandler) UpdateOracle(ctx context.Context, height uint64, extCom
 	}
 
 	h := int64(height) //nolint:gosec
-	if hostStoreLastHeight > h {
+	if hostStoreLastHeight-5 > h {
 		return types.ErrInvalidOracleHeight
 	}
 


### PR DESCRIPTION
### Description

Oracle updates are currently blocked if they occur after an IBC updateClient transaction. This restriction can hinder the oracle update process on Layer 2 (L2), potentially introducing delays in L2 application logic.

To mitigate this issue, we propose introducing a 5-block buffer that allows oracle updates within a safe window after an IBC client update. This buffer ensures smoother L2 operations without compromising synchronization or data integrity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the validation logic for oracle updates to allow a 5-block tolerance window, reducing the likelihood of update rejections due to minor height discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->